### PR TITLE
[tune integration] Don't process nan/inf results

### DIFF
--- a/zoopt/algos/opt_algorithms/racos/sracos.py
+++ b/zoopt/algos/opt_algorithms/racos/sracos.py
@@ -289,6 +289,8 @@ class SRacosTune(RacosCommon):
 
         # Invalid results (nan/inf) should not be added as data
         if np.isnan(result) or np.isinf(result):
+            if self.complete_num == self._parameter.get_train_size():
+                self.semaphore = 1
             return self._best_solution
 
         solution.set_value(result)

--- a/zoopt/algos/opt_algorithms/racos/sracos.py
+++ b/zoopt/algos/opt_algorithms/racos/sracos.py
@@ -286,6 +286,11 @@ class SRacosTune(RacosCommon):
         """
         self.complete_num += 1
         self.live_num -= 1
+
+        # Invalid results (nan/inf) should not be added as data
+        if np.isnan(result) or np.isinf(result):
+            return self._best_solution
+
         solution.set_value(result)
         if self.complete_num < self._parameter.get_train_size():
             self._data.append(solution)


### PR DESCRIPTION
Signed-off-by: Justin Yu <justinvyu@berkeley.edu>

Currently, `nan` results causes the binary search happening inside `SRacosTune.update_classifier` to cause a stack overflow error from continuing to search recursively. This is because `x > nan` and `x < nan` is always false. This PR adds a check for invalid solution results (including nans and infs) when completing a trial.

One question: should `+/- inf` results be processed? Tune usually ignores these along with nans for other search algorithms.